### PR TITLE
Inline boost::multiprecision::int512_t serialization functions

### DIFF
--- a/include/int512_serialization.hpp
+++ b/include/int512_serialization.hpp
@@ -11,12 +11,12 @@ CAF_POP_WARNINGS
 // *not* very good style to open external namespaces,
 // but unfortunately necessary here to get ADL working
 namespace boost { namespace multiprecision {
-void serialize(caf::serializer& s, int512_t& i512) {
+inline void serialize(caf::serializer& s, int512_t& i512) {
   auto& x = i512.backend();
   s << x.sign() << static_cast<uint32_t>(x.size());
   s.apply_raw(x.size() * sizeof(limb_type), x.limbs());
 }
-void serialize(caf::deserializer& d, int512_t& i512) {
+inline void serialize(caf::deserializer& d, int512_t& i512) {
   auto& x = i512.backend();
   bool is_signed;
   uint32_t limbs;


### PR DESCRIPTION
To prevent errors during linking, if the int512_serialization.hpp is
included in multiple compilation units, the serialization functions
were inlined.